### PR TITLE
Remove managed config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,16 @@ test: build
 .PHONY: sentinel keeper proxy stolonctl docker
 
 keeper:
-	GOOS="linux" GOARCH="amd64" GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-keeper $(REPO_PATH)/cmd/keeper
+	GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-keeper $(REPO_PATH)/cmd/keeper
 
 sentinel:
-	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-sentinel $(REPO_PATH)/cmd/sentinel
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-sentinel $(REPO_PATH)/cmd/sentinel
 
 proxy:
-	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-proxy $(REPO_PATH)/cmd/proxy
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-proxy $(REPO_PATH)/cmd/proxy
 
 stolonctl:
-	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolonctl $(REPO_PATH)/cmd/stolonctl
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolonctl $(REPO_PATH)/cmd/stolonctl
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,16 @@ test: build
 .PHONY: sentinel keeper proxy stolonctl docker
 
 keeper:
-	GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-keeper $(REPO_PATH)/cmd/keeper
+	GOOS="linux" GOARCH="amd64" GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-keeper $(REPO_PATH)/cmd/keeper
 
 sentinel:
-	CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-sentinel $(REPO_PATH)/cmd/sentinel
+	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-sentinel $(REPO_PATH)/cmd/sentinel
 
 proxy:
-	CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-proxy $(REPO_PATH)/cmd/proxy
+	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolon-proxy $(REPO_PATH)/cmd/proxy
 
 stolonctl:
-	CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolonctl $(REPO_PATH)/cmd/stolonctl
+	GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 GO111MODULE=on go build -ldflags $(LD_FLAGS) -o $(PROJDIR)/bin/stolonctl $(REPO_PATH)/cmd/stolonctl
 
 .PHONY: docker
 docker:

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -156,7 +156,6 @@ func init() {
 var managedPGParameters = []string{
 	"unix_socket_directories",
 	"wal_keep_segments",
-	"wal_keep_size",
 	"hot_standby",
 	"listen_addresses",
 	"port",


### PR DESCRIPTION
Removes `wal_keep_size` from Stolon's "managed" configuration settings. 